### PR TITLE
Add custom user dictionary support across platforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ A Kotlin Multiplatform library providing spell checking functionality.
       `DictionaryScope.System` uses the native learn API: OS-wide on iOS/macOS, per-user/language on Windows,
       per-user file on Linux (Hunspell). Android has no native learn API and falls back to AppLocal.
       Windows basic `ISpellChecker` does not expose remove, so `removeFromDictionary(_, System)` is a no-op there.
+    - `suspend fun setUserDictionary(words: Collection<String>)` - Atomically replaces the AppLocal set
+      and clears session ignores. Use to swap dictionary contexts without recreating the checker. Does
+      not touch `System` entries; does not clear native platform-level session ignores.
 - **DictionaryScope.kt** - `AppLocal` vs `System` selector for the dictionary mutation methods above.
 - **UserDictionary.kt** - Internal helper that backs the app-local set with case-insensitive,
   thread-safe storage shared by every platform actual.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,15 @@ A Kotlin Multiplatform library providing spell checking functionality.
     - `suspend fun performSpellCheck(text: String): List<SpellingCorrection>` - Check sentences
     - `suspend fun checkWord(word: String, maxSuggestions: Int = 5): WordCheckResult` - Check a single word. Returns
       `CorrectWord` when correct, otherwise `MisspelledWord` with up to `maxSuggestions` suggestions (may be empty).
+    - `suspend fun addToDictionary(word, scope = AppLocal)` / `removeFromDictionary(word, scope)` /
+      `suspend fun ignoreWord(word)` - Custom user-dictionary management. `DictionaryScope.AppLocal` is in-memory
+      for the lifetime of this checker (caller persists via `userDictionary(): Set<String>`).
+      `DictionaryScope.System` uses the native learn API: OS-wide on iOS/macOS, per-user/language on Windows,
+      per-user file on Linux (Hunspell). Android has no native learn API and falls back to AppLocal.
+      Windows basic `ISpellChecker` does not expose remove, so `removeFromDictionary(_, System)` is a no-op there.
+- **DictionaryScope.kt** - `AppLocal` vs `System` selector for the dictionary mutation methods above.
+- **UserDictionary.kt** - Internal helper that backs the app-local set with case-insensitive,
+  thread-safe storage shared by every platform actual.
 
 #### Android Implementation (`androidMain`)
 - **PlatformSpellChecker.android.kt** - Actual implementation using Android's TextServicesManager

--- a/PlatformSpellChecker/src/androidMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.android.kt
+++ b/PlatformSpellChecker/src/androidMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.android.kt
@@ -198,6 +198,10 @@ actual class PlatformSpellChecker(
 		userDict.ignore(word)
 	}
 
+	actual suspend fun setUserDictionary(words: Collection<String>) {
+		userDict.replace(words)
+	}
+
 	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	// SpellCheckerSession dispatches requests over an async IPC bind to the

--- a/PlatformSpellChecker/src/androidMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.android.kt
+++ b/PlatformSpellChecker/src/androidMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.android.kt
@@ -36,6 +36,8 @@ actual class PlatformSpellChecker(
 
 	private val pendingOperations = ConcurrentHashMap<Int, OperationContext>()
 
+	private val userDict = UserDictionary()
+
 	private val spellCheckerSession: SpellCheckerSession by lazy {
 		val targetLocale = locale?.toJavaLocale() ?: java.util.Locale.getDefault()
 
@@ -120,7 +122,7 @@ actual class PlatformSpellChecker(
 
 	actual suspend fun checkMultiword(text: String): List<SpellingCorrection> {
 		if (text.isBlank()) return emptyList()
-		return withTimeoutFailingOpen("checkMultiword", text, emptyList()) {
+		val raw = withTimeoutFailingOpen("checkMultiword", text, emptyList<SpellingCorrection>()) {
 			suspendCancellableCoroutine { continuation ->
 				val trackingId = sequenceGenerator.incrementAndGet()
 				pendingOperations[trackingId] = OperationContext.SentenceCheck(continuation, text)
@@ -133,11 +135,13 @@ actual class PlatformSpellChecker(
 				continuation.invokeOnCancellation { pendingOperations.remove(trackingId) }
 			}
 		}
+		return raw.filterNot { userDict.isKnown(it.misspelledWord) }
 	}
 
 	actual suspend fun checkWord(word: String, maxSuggestions: Int): WordCheckResult {
 		val trimmedWord = word.trim()
 		if (trimmedWord.isEmpty() || trimmedWord.contains(" ")) return CorrectWord(trimmedWord)
+		if (userDict.isKnown(trimmedWord)) return CorrectWord(trimmedWord)
 		val max = if (maxSuggestions <= 0) 5 else maxSuggestions
 
 		return withTimeoutFailingOpen<WordCheckResult>("checkWord", trimmedWord, CorrectWord(trimmedWord)) {
@@ -158,6 +162,7 @@ actual class PlatformSpellChecker(
 	actual suspend fun isWordCorrect(word: String): Boolean {
 		val trimmed = word.trim()
 		if (trimmed.isEmpty() || trimmed.contains(" ")) return false
+		if (userDict.isKnown(trimmed)) return true
 
 		return withTimeoutFailingOpen("isWordCorrect", trimmed, true) {
 			suspendCancellableCoroutine { continuation ->
@@ -170,6 +175,30 @@ actual class PlatformSpellChecker(
 			}
 		}
 	}
+
+	actual suspend fun addToDictionary(word: String, scope: DictionaryScope) {
+		// SpellCheckerSession has no native add/learn API and the system
+		// UserDictionary provider requires the signature-level
+		// WRITE_USER_DICTIONARY permission as of API 23, so System falls back
+		// to app-local persistence regardless of caller intent.
+		if (scope == DictionaryScope.System) {
+			Napier.w("DictionaryScope.System is not supported on Android; falling back to AppLocal")
+		}
+		userDict.add(word)
+	}
+
+	actual suspend fun removeFromDictionary(word: String, scope: DictionaryScope) {
+		if (scope == DictionaryScope.System) {
+			Napier.w("DictionaryScope.System is not supported on Android; falling back to AppLocal")
+		}
+		userDict.remove(word)
+	}
+
+	actual suspend fun ignoreWord(word: String) {
+		userDict.ignore(word)
+	}
+
+	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	// SpellCheckerSession dispatches requests over an async IPC bind to the
 	// provider app. If the bind never completes — e.g. the provider's process

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/DictionaryScope.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/DictionaryScope.kt
@@ -1,0 +1,31 @@
+package com.darkrockstudios.libs.platformspellchecker
+
+/**
+ * Scope of a custom-dictionary mutation.
+ *
+ * Spell-check results always treat [AppLocal] words as correct on every platform.
+ * [System] additionally delegates to the platform's native learn/unlearn mechanism
+ * where one exists.
+ */
+enum class DictionaryScope {
+	/**
+	 * In-memory, app-private. Persists only for the lifetime of this
+	 * [PlatformSpellChecker] instance. Callers that want cross-session
+	 * persistence should snapshot via [PlatformSpellChecker.userDictionary] and
+	 * re-seed on startup.
+	 */
+	AppLocal,
+
+	/**
+	 * Uses the platform's native user-dictionary mechanism, which persists
+	 * across app restarts. Scope of that persistence varies:
+	 *  - iOS / macOS: OS-wide (shared with every app on the device).
+	 *  - Windows: per-user, per-language Windows dictionary.
+	 *  - Linux (Hunspell): per-user file at `~/.local/share/hunspell/{lang}_user.dic`.
+	 *  - Android: no native API exists; falls back to [AppLocal] with a warning.
+	 *
+	 * Removal support is best-effort and not available everywhere (e.g. Windows
+	 * basic ISpellChecker does not expose remove).
+	 */
+	System,
+}

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.kt
@@ -63,6 +63,21 @@ expect class PlatformSpellChecker {
 	suspend fun ignoreWord(word: String)
 
 	/**
+	 * Atomically replaces the [DictionaryScope.AppLocal] user dictionary with
+	 * [words] (normalized the same way as [addToDictionary]: trimmed,
+	 * case-insensitive) and resets this checker's session ignore set. Use to
+	 * switch between independent dictionary contexts without tearing down the
+	 * checker.
+	 *
+	 * Does not touch [DictionaryScope.System] entries — those live in the OS
+	 * dictionary. Does not clear native platform-level session ignores
+	 * (UITextChecker, NSSpellChecker, Hunspell, ISpellChecker retain them
+	 * until [close]); callers that rely heavily on [ignoreWord] should close
+	 * and recreate the checker for a fully clean slate.
+	 */
+	suspend fun setUserDictionary(words: Collection<String>)
+
+	/**
 	 * @return a snapshot of the words currently in the app-local user dictionary.
 	 * Useful for persisting the dictionary between app sessions. Does not include
 	 * words added with [DictionaryScope.System] on platforms with native learn

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.kt
@@ -12,20 +12,63 @@ expect class PlatformSpellChecker {
 	 * Returns a list of [SpellingCorrection] objects containing the misspelled words,
 	 * their positions in the original text, and suggested corrections.
 	 * Returns an empty list if no spelling errors are found.
+	 *
+	 * Words added via [addToDictionary] (any scope) and words passed to
+	 * [ignoreWord] are filtered out of the results.
 	 */
 	suspend fun checkMultiword(text: String): List<SpellingCorrection>
 
 	/**
 	 * Checks a single word and returns a structured result indicating if it is spelled correctly.
 	 * When misspelled, includes up to [maxSuggestions] suggestions (may be empty).
+	 *
+	 * Words in the user dictionary (see [addToDictionary]) or marked via
+	 * [ignoreWord] are reported as [CorrectWord].
 	 */
 	suspend fun checkWord(word: String, maxSuggestions: Int = 5): WordCheckResult
 
 	/**
 	 * Checks if a single word exists in the active dictionary and is considered correctly spelled.
-	 * Returns true when the word is recognized by the platform spell checker; false otherwise.
+	 * Returns true when the word is recognized by the platform spell checker or appears in the
+	 * user dictionary (see [addToDictionary]) or session ignores (see [ignoreWord]); false otherwise.
 	 */
 	suspend fun isWordCorrect(word: String): Boolean
+
+	/**
+	 * Adds [word] to the user dictionary. Subsequent spell checks will treat it
+	 * as correctly spelled.
+	 *
+	 * @param scope Controls persistence semantics. See [DictionaryScope] for details.
+	 * Defaults to [DictionaryScope.AppLocal] for predictability across platforms.
+	 */
+	suspend fun addToDictionary(word: String, scope: DictionaryScope = DictionaryScope.AppLocal)
+
+	/**
+	 * Removes [word] from the user dictionary previously added via [addToDictionary].
+	 *
+	 * For [DictionaryScope.System], removal is best-effort: supported on iOS,
+	 * macOS, and Linux (Hunspell). On Windows the basic spell-check API does not
+	 * expose a remove operation; the call is a no-op and logs a warning. On
+	 * Android it falls back to [DictionaryScope.AppLocal].
+	 */
+	suspend fun removeFromDictionary(word: String, scope: DictionaryScope = DictionaryScope.AppLocal)
+
+	/**
+	 * Marks [word] as ignored for the lifetime of this checker. Unlike
+	 * [addToDictionary], ignores are not persisted and are not returned by
+	 * [userDictionary]. Where the platform provides a native ignore facility
+	 * (iOS, macOS, Windows, Linux/Hunspell) it is used; otherwise the word is
+	 * filtered out of results in this library.
+	 */
+	suspend fun ignoreWord(word: String)
+
+	/**
+	 * @return a snapshot of the words currently in the app-local user dictionary.
+	 * Useful for persisting the dictionary between app sessions. Does not include
+	 * words added with [DictionaryScope.System] on platforms with native learn
+	 * support, since those are owned by the OS.
+	 */
+	fun userDictionary(): Set<String>
 
 	/**
 	 * Releases any platform resources held by the spell checker (if applicable).

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
@@ -38,7 +38,11 @@ internal class UserDictionary {
 		mutex.withLock { ignoredWords = ignoredWords + key }
 	}
 
-	fun snapshot(): Set<String> = addedWords
+	// Returns a defensive copy: the volatile `addedWords` is the LinkedHashSet
+	// returned by Set.plus, and handing it out directly lets a caller downcast
+	// to MutableSet and corrupt internal state until the next mutation
+	// reassigns the reference.
+	fun snapshot(): Set<String> = addedWords.toSet()
 
 	/** True when [word] should be treated as correctly spelled by the caller. */
 	fun isKnown(word: String): Boolean {

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
@@ -1,0 +1,50 @@
+package com.darkrockstudios.libs.platformspellchecker
+
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Internal helper shared by every platform's [PlatformSpellChecker] actual to
+ * track app-local additions and per-session ignores. Reads use volatile
+ * snapshots so the spell-check hot path stays lock-free; mutations are
+ * serialized under a coroutine [Mutex].
+ *
+ * Matching is case-insensitive and trims whitespace, matching the convention
+ * used by [com.darkrockstudios.libs.platformspellchecker.linux.HunspellWrapper]
+ * and the macOS wrapper.
+ */
+internal class UserDictionary {
+	private val mutex = Mutex()
+
+	@Volatile
+	private var addedWords: Set<String> = emptySet()
+
+	@Volatile
+	private var ignoredWords: Set<String> = emptySet()
+
+	suspend fun add(word: String) {
+		val key = word.normalize() ?: return
+		mutex.withLock { addedWords = addedWords + key }
+	}
+
+	suspend fun remove(word: String) {
+		val key = word.normalize() ?: return
+		mutex.withLock { addedWords = addedWords - key }
+	}
+
+	suspend fun ignore(word: String) {
+		val key = word.normalize() ?: return
+		mutex.withLock { ignoredWords = ignoredWords + key }
+	}
+
+	fun snapshot(): Set<String> = addedWords
+
+	/** True when [word] should be treated as correctly spelled by the caller. */
+	fun isKnown(word: String): Boolean {
+		val key = word.normalize() ?: return false
+		return addedWords.contains(key) || ignoredWords.contains(key)
+	}
+
+	private fun String.normalize(): String? = trim().lowercase().takeIf { it.isNotEmpty() }
+}

--- a/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
+++ b/PlatformSpellChecker/src/commonMain/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionary.kt
@@ -38,6 +38,20 @@ internal class UserDictionary {
 		mutex.withLock { ignoredWords = ignoredWords + key }
 	}
 
+	/**
+	 * Atomically replaces [addedWords] with the normalized form of [words] and
+	 * clears [ignoredWords]. A single mutex acquire instead of n round-trips
+	 * through [add], and either every read sees the old dictionary or every
+	 * read sees the new one — never a partial view.
+	 */
+	suspend fun replace(words: Collection<String>) {
+		val normalized = words.mapNotNullTo(LinkedHashSet<String>()) { it.normalize() }
+		mutex.withLock {
+			addedWords = normalized
+			ignoredWords = emptySet()
+		}
+	}
+
 	// Returns a defensive copy: the volatile `addedWords` is the LinkedHashSet
 	// returned by Set.plus, and handing it out directly lets a caller downcast
 	// to MutableSet and corrupt internal state until the next mutation

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.desktop.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.desktop.kt
@@ -187,6 +187,10 @@ actual class PlatformSpellChecker(
 		userDict.ignore(trimmed)
 	}
 
+	actual suspend fun setUserDictionary(words: Collection<String>) {
+		userDict.replace(words)
+	}
+
 	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	actual override fun close() {

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.desktop.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.desktop.kt
@@ -19,6 +19,8 @@ actual class PlatformSpellChecker(
 	private val locale: SpLocale? = null
 ) : AutoCloseable {
 
+	private val userDict = UserDictionary()
+
 	private val spellChecker: NativeSpellChecker? by lazy {
 		try {
 			val checker = if (locale != null) {
@@ -50,6 +52,7 @@ actual class PlatformSpellChecker(
 
 			errors.mapNotNull { error ->
 				val misspelledWord = text.substring(error.startIndex, error.startIndex + error.length)
+				if (userDict.isKnown(misspelledWord)) return@mapNotNull null
 
 				when (error.correctiveAction) {
 					CorrectiveAction.GET_SUGGESTIONS -> {
@@ -97,6 +100,7 @@ actual class PlatformSpellChecker(
 	actual suspend fun checkWord(word: String, maxSuggestions: Int): WordCheckResult = withContext(Dispatchers.IO) {
 		val trimmed = word.trim()
 		if (trimmed.isEmpty() || trimmed.contains(" ")) return@withContext CorrectWord(trimmed)
+		if (userDict.isKnown(trimmed)) return@withContext CorrectWord(trimmed)
 
 		val checker = spellChecker ?: return@withContext CorrectWord(trimmed)
 
@@ -117,6 +121,7 @@ actual class PlatformSpellChecker(
 	actual suspend fun isWordCorrect(word: String): Boolean = withContext(Dispatchers.IO) {
 		val trimmed = word.trim()
 		if (trimmed.isEmpty() || trimmed.contains(" ")) return@withContext false
+		if (userDict.isKnown(trimmed)) return@withContext true
 
 		val checker = spellChecker ?: return@withContext false
 		return@withContext try {
@@ -126,6 +131,63 @@ actual class PlatformSpellChecker(
 			false
 		}
 	}
+
+	actual suspend fun addToDictionary(word: String, scope: DictionaryScope) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		when (scope) {
+			DictionaryScope.AppLocal -> userDict.add(trimmed)
+			DictionaryScope.System -> withContext(Dispatchers.IO) {
+				val checker = spellChecker
+				if (checker == null) {
+					Napier.w("addToDictionary(System): no native spell checker available; falling back to AppLocal")
+					userDict.add(trimmed)
+					return@withContext
+				}
+				try {
+					checker.addToDictionary(trimmed)
+				} catch (e: Exception) {
+					Napier.e("Error adding '$trimmed' to system dictionary: ${e.message}", e)
+				}
+			}
+		}
+	}
+
+	actual suspend fun removeFromDictionary(word: String, scope: DictionaryScope) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		when (scope) {
+			DictionaryScope.AppLocal -> userDict.remove(trimmed)
+			DictionaryScope.System -> withContext(Dispatchers.IO) {
+				val checker = spellChecker
+				if (checker == null) {
+					Napier.w("removeFromDictionary(System): no native spell checker available; falling back to AppLocal")
+					userDict.remove(trimmed)
+					return@withContext
+				}
+				try {
+					checker.removeFromDictionary(trimmed)
+				} catch (e: Exception) {
+					Napier.e("Error removing '$trimmed' from system dictionary: ${e.message}", e)
+				}
+			}
+		}
+	}
+
+	actual suspend fun ignoreWord(word: String) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		withContext(Dispatchers.IO) {
+			try {
+				spellChecker?.ignoreWord(trimmed)
+			} catch (e: Exception) {
+				Napier.e("Error ignoring '$trimmed': ${e.message}", e)
+			}
+		}
+		userDict.ignore(trimmed)
+	}
+
+	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	actual override fun close() {
 		runCatching { spellChecker?.close() }

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
@@ -144,7 +144,7 @@ class HunspellWrapper private constructor(
 			try {
 				val target = word.trim()
 				val remaining = dictFile.readLines()
-					.filter { it.trim() != target }
+					.filter { !it.trim().equals(target, ignoreCase = true) }
 				dictFile.writeText(if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n")
 				Napier.d("Removed '$word' from user dictionary: $dictFile")
 			} catch (e: Exception) {

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
@@ -32,6 +32,12 @@ class HunspellWrapper private constructor(
 	private val ignoredWords = mutableSetOf<String>()
 	private val userDictionaryPath: File? = getUserDictionaryPath(languageTag)
 
+	// Serializes the user-dictionary mutations below (runtime add/remove +
+	// persisted-file append/rewrite). Without this, two concurrent calls can
+	// interleave their read-modify-write of the file and lose entries, or
+	// leave runtime and on-disk state divergent.
+	private val userDictLock = Any()
+
 	/**
 	 * Checks if a word is spelled correctly.
 	 */
@@ -98,17 +104,19 @@ class HunspellWrapper private constructor(
 		check(!closed.get()) { "HunspellWrapper has been closed" }
 		if (word.isBlank()) return
 
-		// Add to runtime dictionary
-		addWord(word)
+		synchronized(userDictLock) {
+			// Add to runtime dictionary
+			addWord(word)
 
-		// Persist to user dictionary file
-		userDictionaryPath?.let { dictFile ->
-			try {
-				dictFile.parentFile?.mkdirs()
-				dictFile.appendText("$word\n")
-				Napier.d("Added '$word' to user dictionary: $dictFile")
-			} catch (e: Exception) {
-				Napier.e("Failed to write to user dictionary: ${e.message}", e)
+			// Persist to user dictionary file
+			userDictionaryPath?.let { dictFile ->
+				try {
+					dictFile.parentFile?.mkdirs()
+					dictFile.appendText("$word\n")
+					Napier.d("Added '$word' to user dictionary: $dictFile")
+				} catch (e: Exception) {
+					Napier.e("Failed to write to user dictionary: ${e.message}", e)
+				}
 			}
 		}
 	}
@@ -140,33 +148,35 @@ class HunspellWrapper private constructor(
 		check(!closed.get()) { "HunspellWrapper has been closed" }
 		if (word.isBlank()) return
 
-		removeWord(word)
+		synchronized(userDictLock) {
+			removeWord(word)
 
-		userDictionaryPath?.let { dictFile ->
-			if (!dictFile.exists()) return@let
-			try {
-				val target = word.trim()
-				val remaining = dictFile.readLines()
-					.filter { !it.trim().equals(target, ignoreCase = true) }
-				val newContent = if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n"
-				// Write to a sibling temp file and atomically rename. On POSIX
-				// (rename(2)) this is atomic, so a crash mid-write leaves the
-				// original file intact instead of truncated/empty.
-				val tmp = File(dictFile.parentFile, "${dictFile.name}.tmp")
-				tmp.writeText(newContent)
+			userDictionaryPath?.let { dictFile ->
+				if (!dictFile.exists()) return@let
 				try {
-					Files.move(
-						tmp.toPath(),
-						dictFile.toPath(),
-						StandardCopyOption.ATOMIC_MOVE,
-						StandardCopyOption.REPLACE_EXISTING,
-					)
-				} catch (_: AtomicMoveNotSupportedException) {
-					Files.move(tmp.toPath(), dictFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+					val target = word.trim()
+					val remaining = dictFile.readLines()
+						.filter { !it.trim().equals(target, ignoreCase = true) }
+					val newContent = if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n"
+					// Write to a sibling temp file and atomically rename. On POSIX
+					// (rename(2)) this is atomic, so a crash mid-write leaves the
+					// original file intact instead of truncated/empty.
+					val tmp = File(dictFile.parentFile, "${dictFile.name}.tmp")
+					tmp.writeText(newContent)
+					try {
+						Files.move(
+							tmp.toPath(),
+							dictFile.toPath(),
+							StandardCopyOption.ATOMIC_MOVE,
+							StandardCopyOption.REPLACE_EXISTING,
+						)
+					} catch (_: AtomicMoveNotSupportedException) {
+						Files.move(tmp.toPath(), dictFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+					}
+					Napier.d("Removed '$word' from user dictionary: $dictFile")
+				} catch (e: Exception) {
+					Napier.e("Failed to rewrite user dictionary: ${e.message}", e)
 				}
-				Napier.d("Removed '$word' from user dictionary: $dictFile")
-			} catch (e: Exception) {
-				Napier.e("Failed to rewrite user dictionary: ${e.message}", e)
 			}
 		}
 	}

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
@@ -128,6 +128,31 @@ class HunspellWrapper private constructor(
 		library.Hunspell_remove(handle, word)
 	}
 
+	/**
+	 * Removes a word from the user's personal dictionary, both at runtime and
+	 * from the persisted user-dictionary file. No-op if the word was not in
+	 * the file.
+	 */
+	fun removeFromUserDictionary(word: String) {
+		check(!closed.get()) { "HunspellWrapper has been closed" }
+		if (word.isBlank()) return
+
+		removeWord(word)
+
+		userDictionaryPath?.let { dictFile ->
+			if (!dictFile.exists()) return@let
+			try {
+				val target = word.trim()
+				val remaining = dictFile.readLines()
+					.filter { it.trim() != target }
+				dictFile.writeText(if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n")
+				Napier.d("Removed '$word' from user dictionary: $dictFile")
+			} catch (e: Exception) {
+				Napier.e("Failed to rewrite user dictionary: ${e.message}", e)
+			}
+		}
+	}
+
 	override fun close() {
 		if (closed.compareAndSet(false, true)) {
 			library.Hunspell_destroy(handle)

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/linux/HunspellWrapper.kt
@@ -6,6 +6,9 @@ import com.sun.jna.ptr.PointerByReference
 import io.github.aakira.napier.Napier
 import java.io.File
 import java.nio.charset.Charset
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -145,7 +148,22 @@ class HunspellWrapper private constructor(
 				val target = word.trim()
 				val remaining = dictFile.readLines()
 					.filter { !it.trim().equals(target, ignoreCase = true) }
-				dictFile.writeText(if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n")
+				val newContent = if (remaining.isEmpty()) "" else remaining.joinToString("\n") + "\n"
+				// Write to a sibling temp file and atomically rename. On POSIX
+				// (rename(2)) this is atomic, so a crash mid-write leaves the
+				// original file intact instead of truncated/empty.
+				val tmp = File(dictFile.parentFile, "${dictFile.name}.tmp")
+				tmp.writeText(newContent)
+				try {
+					Files.move(
+						tmp.toPath(),
+						dictFile.toPath(),
+						StandardCopyOption.ATOMIC_MOVE,
+						StandardCopyOption.REPLACE_EXISTING,
+					)
+				} catch (_: AtomicMoveNotSupportedException) {
+					Files.move(tmp.toPath(), dictFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+				}
 				Napier.d("Removed '$word' from user dictionary: $dictFile")
 			} catch (e: Exception) {
 				Napier.e("Failed to rewrite user dictionary: ${e.message}", e)

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/macos/NSSpellCheckerWrapper.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/macos/NSSpellCheckerWrapper.kt
@@ -85,6 +85,19 @@ class NSSpellCheckerWrapper private constructor(private val spellChecker: Pointe
 	}
 
 	/**
+	 * Removes a word previously added via [learnWord].
+	 */
+	fun unlearnWord(word: String) {
+		val nsWord = ObjC.createNSString(word) ?: return
+		try {
+			val selector = ObjC.selector("unlearnWord:") ?: return
+			ObjC.msgSend(spellChecker, selector, nsWord)
+		} finally {
+			ObjC.release(nsWord)
+		}
+	}
+
+	/**
 	 * Ignores a word for this session.
 	 */
 	fun ignoreWord(word: String) {

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/LinuxSpellChecker.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/LinuxSpellChecker.kt
@@ -77,6 +77,11 @@ class LinuxSpellChecker private constructor(
 		hunspell.addToUserDictionary(word.trim())
 	}
 
+	override fun removeFromDictionary(word: String) {
+		if (word.isBlank()) return
+		hunspell.removeFromUserDictionary(word.trim())
+	}
+
 	override fun ignoreWord(word: String) {
 		if (word.isBlank()) return
 		hunspell.ignoreWord(word.trim())

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/MacOSSpellChecker.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/MacOSSpellChecker.kt
@@ -109,6 +109,16 @@ class MacOSSpellChecker private constructor(
 		}
 	}
 
+	override fun removeFromDictionary(word: String) {
+		if (word.isBlank()) return
+
+		try {
+			spellChecker.unlearnWord(word.trim())
+		} catch (e: Exception) {
+			Napier.e("Error removing word from dictionary: ${e.message}", e)
+		}
+	}
+
 	override fun ignoreWord(word: String) {
 		if (word.isBlank()) return
 

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/NativeSpellChecker.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/native/NativeSpellChecker.kt
@@ -47,6 +47,15 @@ interface NativeSpellChecker : AutoCloseable {
 	fun addToDictionary(word: String)
 
 	/**
+	 * Removes a word previously added via [addToDictionary]. Best-effort:
+	 * platforms whose native API does not expose a remove operation should
+	 * log a warning and no-op.
+	 *
+	 * @param word The word to remove
+	 */
+	fun removeFromDictionary(word: String)
+
+	/**
 	 * Ignores a word for this session.
 	 *
 	 * @param word The word to ignore

--- a/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/windows/WindowsSpellChecker.kt
+++ b/PlatformSpellChecker/src/desktopMain/kotlin/com/darkrockstudios/libs/platformspellchecker/windows/WindowsSpellChecker.kt
@@ -6,6 +6,7 @@ import com.sun.jna.platform.win32.COM.COMUtils
 import com.sun.jna.platform.win32.Ole32
 import com.sun.jna.platform.win32.WTypes
 import com.sun.jna.ptr.PointerByReference
+import io.github.aakira.napier.Napier
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -105,6 +106,17 @@ class WindowsSpellChecker private constructor(
 	override fun addToDictionary(word: String) {
 		check(!closed.get()) { "WindowsSpellChecker has been closed" }
 		spellChecker.add(word)
+	}
+
+	/**
+	 * No-op on Windows: the basic [ISpellChecker] VTable does not expose a
+	 * remove operation. Removal would require [ISpellChecker2] (Windows 8.1+),
+	 * which is not currently bound. Logs a warning so callers know the request
+	 * was dropped.
+	 */
+	override fun removeFromDictionary(word: String) {
+		check(!closed.get()) { "WindowsSpellChecker has been closed" }
+		Napier.w("removeFromDictionary is not supported by the Windows basic ISpellChecker API (word='$word')")
 	}
 
 	/**

--- a/PlatformSpellChecker/src/desktopTest/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionaryTest.kt
+++ b/PlatformSpellChecker/src/desktopTest/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionaryTest.kt
@@ -1,0 +1,68 @@
+package com.darkrockstudios.libs.platformspellchecker
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the internal [UserDictionary] helper. These run on every host
+ * because they don't touch the native spell-checker backends.
+ */
+class UserDictionaryTest {
+
+	@Test
+	fun `added word is reported as known`() = runTest {
+		val dict = UserDictionary()
+		assertFalse(dict.isKnown("kotlin"))
+
+		dict.add("kotlin")
+		assertTrue(dict.isKnown("kotlin"))
+	}
+
+	@Test
+	fun `lookup is case-insensitive and trims`() = runTest {
+		val dict = UserDictionary()
+		dict.add("Wavesonics")
+
+		assertTrue(dict.isKnown("wavesonics"))
+		assertTrue(dict.isKnown("WAVESONICS"))
+		assertTrue(dict.isKnown("  Wavesonics  "))
+	}
+
+	@Test
+	fun `remove deletes only that word`() = runTest {
+		val dict = UserDictionary()
+		dict.add("alpha")
+		dict.add("beta")
+
+		dict.remove("alpha")
+
+		assertFalse(dict.isKnown("alpha"))
+		assertTrue(dict.isKnown("beta"))
+	}
+
+	@Test
+	fun `ignored words count as known but are not in snapshot`() = runTest {
+		val dict = UserDictionary()
+		dict.add("alpha")
+		dict.ignore("beta")
+
+		assertTrue(dict.isKnown("alpha"))
+		assertTrue(dict.isKnown("beta"))
+
+		assertEquals(setOf("alpha"), dict.snapshot())
+	}
+
+	@Test
+	fun `blank inputs are ignored`() = runTest {
+		val dict = UserDictionary()
+		dict.add("")
+		dict.add("   ")
+		dict.ignore("\t\n")
+
+		assertFalse(dict.isKnown(""))
+		assertEquals(emptySet(), dict.snapshot())
+	}
+}

--- a/PlatformSpellChecker/src/desktopTest/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionaryTest.kt
+++ b/PlatformSpellChecker/src/desktopTest/kotlin/com/darkrockstudios/libs/platformspellchecker/UserDictionaryTest.kt
@@ -65,4 +65,33 @@ class UserDictionaryTest {
 		assertFalse(dict.isKnown(""))
 		assertEquals(emptySet(), dict.snapshot())
 	}
+
+	@Test
+	fun `replace swaps added words and clears ignores`() = runTest {
+		val dict = UserDictionary()
+		dict.add("alpha")
+		dict.ignore("gamma")
+		assertTrue(dict.isKnown("alpha"))
+		assertTrue(dict.isKnown("gamma"))
+
+		dict.replace(listOf("Beta", "delta"))
+
+		assertFalse(dict.isKnown("alpha"))
+		assertFalse(dict.isKnown("gamma"))
+		assertTrue(dict.isKnown("beta"))
+		assertTrue(dict.isKnown("DELTA"))
+		assertEquals(setOf("beta", "delta"), dict.snapshot())
+	}
+
+	@Test
+	fun `replace with empty collection clears the dictionary`() = runTest {
+		val dict = UserDictionary()
+		dict.add("alpha")
+		dict.add("beta")
+
+		dict.replace(emptyList())
+
+		assertFalse(dict.isKnown("alpha"))
+		assertEquals(emptySet(), dict.snapshot())
+	}
 }

--- a/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
+++ b/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.libs.platformspellchecker
 
+import io.github.aakira.napier.Napier
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import platform.Foundation.*
@@ -158,11 +159,16 @@ actual class PlatformSpellChecker(
 	actual suspend fun ignoreWord(word: String) {
 		val trimmed = word.trim()
 		if (trimmed.isEmpty()) return
-		textChecker.ignoreWord(trimmed)
-		// Also mirror to the local set so isWordCorrect/checkWord (which check
-		// the spell-checker via range queries) see the ignore on the very next
-		// call. UITextChecker.ignoreWord influences rangeOfMisspelledWord too,
-		// but mirroring keeps semantics consistent if Apple changes that.
+		try {
+			textChecker.ignoreWord(trimmed)
+		} catch (e: Exception) {
+			Napier.e("Error ignoring '$trimmed': ${e.message}", e)
+		}
+		// Mirror to the local set so isWordCorrect/checkWord (which check the
+		// spell-checker via range queries) see the ignore on the very next
+		// call, even if the native call above threw. UITextChecker.ignoreWord
+		// already influences rangeOfMisspelledWord; mirroring keeps semantics
+		// consistent if Apple changes that.
 		userDict.ignore(trimmed)
 	}
 

--- a/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
+++ b/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
@@ -17,6 +17,7 @@ actual class PlatformSpellChecker(
 ) : AutoCloseable {
 
 	private val textChecker = UITextChecker()
+	private val userDict = UserDictionary()
 	private val language: String by lazy {
 		// Determine the language tag for UITextChecker (expects underscore format like en_US)
 		if (locale != null) {
@@ -74,14 +75,15 @@ actual class PlatformSpellChecker(
 
 			val suggestionList = suggestions?.mapNotNull { it as? String } ?: emptyList()
 
-			// Create SpellingCorrection object
-			val correction = SpellingCorrection(
-				misspelledWord = misspelledWord,
-				startIndex = misspelledRange.useContents { location.toInt() },
-				length = misspelledRange.useContents { length.toInt() },
-				suggestions = suggestionList
-			)
-			results.add(correction)
+			if (!userDict.isKnown(misspelledWord)) {
+				val correction = SpellingCorrection(
+					misspelledWord = misspelledWord,
+					startIndex = misspelledRange.useContents { location.toInt() },
+					length = misspelledRange.useContents { length.toInt() },
+					suggestions = suggestionList
+				)
+				results.add(correction)
+			}
 
 			// Move to the next position after this misspelled word
 			currentOffset = misspelledRange.useContents { location + length }
@@ -93,6 +95,7 @@ actual class PlatformSpellChecker(
 	actual suspend fun checkWord(word: String, maxSuggestions: Int): WordCheckResult {
 		val trimmed = word.trim()
 		if (trimmed.isEmpty() || trimmed.contains(" ")) return CorrectWord(trimmed)
+		if (userDict.isKnown(trimmed)) return CorrectWord(trimmed)
 
 		val range = NSMakeRange(0u, trimmed.length.toULong())
 
@@ -121,6 +124,7 @@ actual class PlatformSpellChecker(
 
 	actual suspend fun isWordCorrect(word: String): Boolean {
 		if (word.isBlank()) return false
+		if (userDict.isKnown(word.trim())) return true
 
 		val range = NSMakeRange(0u, word.length.toULong())
 		val misspelledRange = textChecker.rangeOfMisspelledWordInString(
@@ -132,6 +136,37 @@ actual class PlatformSpellChecker(
 		)
 		return misspelledRange.useContents { location } == NSNotFound.toULong()
 	}
+
+	actual suspend fun addToDictionary(word: String, scope: DictionaryScope) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		when (scope) {
+			DictionaryScope.AppLocal -> userDict.add(trimmed)
+			DictionaryScope.System -> UITextChecker.learnWord(trimmed)
+		}
+	}
+
+	actual suspend fun removeFromDictionary(word: String, scope: DictionaryScope) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		when (scope) {
+			DictionaryScope.AppLocal -> userDict.remove(trimmed)
+			DictionaryScope.System -> UITextChecker.unlearnWord(trimmed)
+		}
+	}
+
+	actual suspend fun ignoreWord(word: String) {
+		val trimmed = word.trim()
+		if (trimmed.isEmpty()) return
+		textChecker.ignoreWord(trimmed)
+		// Also mirror to the local set so isWordCorrect/checkWord (which check
+		// the spell-checker via range queries) see the ignore on the very next
+		// call. UITextChecker.ignoreWord influences rangeOfMisspelledWord too,
+		// but mirroring keeps semantics consistent if Apple changes that.
+		userDict.ignore(trimmed)
+	}
+
+	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	actual override fun close() {
 		// No resources to free for UITextChecker

--- a/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
+++ b/PlatformSpellChecker/src/iosMain/kotlin/com/darkrockstudios/libs/platformspellchecker/PlatformSpellChecker.ios.kt
@@ -172,6 +172,10 @@ actual class PlatformSpellChecker(
 		userDict.ignore(trimmed)
 	}
 
+	actual suspend fun setUserDictionary(words: Collection<String>) {
+		userDict.replace(words)
+	}
+
 	actual fun userDictionary(): Set<String> = userDict.snapshot()
 
 	actual override fun close() {


### PR DESCRIPTION
Introduces `addToDictionary`, `removeFromDictionary`, `ignoreWord`,
and `userDictionary()` on the common `PlatformSpellChecker` API, plus a
`DictionaryScope` selector. AppLocal storage is in-memory, app-private,
and uniformly filtered out of every check result; System scope delegates
to the platform's native learn mechanism (UITextChecker, NSSpellChecker,
ISpellChecker, Hunspell user dict) and falls back to AppLocal on Android
where SpellCheckerSession exposes no add API.